### PR TITLE
Two minor fixes/tweaks

### DIFF
--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -179,11 +179,15 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         // Generate the client Node and Browser configuration files. These
         // files are switched between in package.json based on the targeted
         // environment.
-        RuntimeConfigGenerator configGenerator = new RuntimeConfigGenerator(
-                settings, model, symbolProvider, writers, integrations);
-        for (LanguageTarget target : LanguageTarget.values()) {
-            LOGGER.fine("Generating " + target + " runtime configuration");
-            configGenerator.generate(target);
+        if (settings.generateClient()) {
+            // For now these are only generated for clients.
+            // TODO: generate ssdk config
+            RuntimeConfigGenerator configGenerator = new RuntimeConfigGenerator(
+                    settings, model, symbolProvider, writers, integrations);
+            for (LanguageTarget target : LanguageTarget.values()) {
+                LOGGER.fine("Generating " + target + " runtime configuration");
+                configGenerator.generate(target);
+            }
         }
 
         // Write each custom file.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -297,8 +297,14 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
                 context.setSettings(settings);
                 context.setSymbolProvider(symbolProvider);
                 context.setWriter(writer);
-                protocolGenerator.generateRequestSerializers(context);
-                protocolGenerator.generateResponseDeserializers(context);
+                if (context.getSettings().generateClient()) {
+                    protocolGenerator.generateRequestSerializers(context);
+                    protocolGenerator.generateResponseDeserializers(context);
+                }
+                if (context.getSettings().generateServerSdk()) {
+                    protocolGenerator.generateRequestDeserializers(context);
+                    protocolGenerator.generateResponseSerializers(context);
+                }
                 protocolGenerator.generateSharedComponents(context);
             });
         }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CodegenVisitor.java
@@ -197,7 +197,7 @@ class CodegenVisitor extends ShapeVisitor.Default<Void> {
         }
 
         // Generate index for client.
-        IndexGenerator.writeIndex(settings, model, symbolProvider, fileManifest);
+        IndexGenerator.writeIndex(settings, model, symbolProvider, fileManifest, protocolGenerator);
 
         // Generate protocol tests IFF found in the model.
         if (protocolGenerator != null) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/CommandGenerator.java
@@ -85,6 +85,13 @@ final class CommandGenerator implements Runnable {
 
     @Override
     public void run() {
+        addInputAndOutputTypes();
+        if (settings.generateClient()) {
+            generateClientCommand();
+        }
+    }
+
+    private void generateClientCommand() {
         Symbol serviceSymbol = symbolProvider.toSymbol(service);
         String configType = ServiceGenerator.getResolvedConfigTypeName(serviceSymbol);
 

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/IndexGenerator.java
@@ -42,6 +42,22 @@ final class IndexGenerator {
         FileManifest fileManifest
     ) {
         TypeScriptWriter writer = new TypeScriptWriter("");
+
+        if (settings.generateClient()) {
+            writeClientExports(settings, model, symbolProvider, writer);
+        }
+
+        // write export statement for models
+        writer.write("export * from \"./models/index\";");
+        fileManifest.writeFile("index.ts", writer.toString());
+    }
+
+    private static void writeClientExports(
+            TypeScriptSettings settings,
+            Model model,
+            SymbolProvider symbolProvider,
+            TypeScriptWriter writer
+    ) {
         ServiceShape service = settings.getService(model);
         Symbol symbol = symbolProvider.toSymbol(service);
 
@@ -75,9 +91,5 @@ final class IndexGenerator {
             String modulePath = PaginationGenerator.PAGINATION_INTERFACE_FILE;
             writer.write("export * from \"./$L\";", modulePath.replace(".ts", ""));
         }
-
-        // write export statement for models
-        writer.write("export * from \"./models/index\";");
-        fileManifest.writeFile("index.ts", writer.toString());
     }
 }

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageJsonGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/PackageJsonGenerator.java
@@ -51,12 +51,15 @@ final class PackageJsonGenerator {
             node = node.withMember(depEntry.getKey(), builder.build());
         }
 
-        // Add the Node vs Browser hook.
-        node = node.withMember("browser", Node.objectNode()
-                .withMember("./runtimeConfig", "./runtimeConfig.browser"));
-        // Add the ReactNative hook.
-        node = node.withMember("react-native", Node.objectNode()
-                .withMember("./runtimeConfig", "./runtimeConfig.native"));
+        // These are currently only generated for clients, but they may be needed for ssdk as well.
+        if (settings.generateClient()) {
+            // Add the Node vs Browser hook.
+            node = node.withMember("browser", Node.objectNode()
+                    .withMember("./runtimeConfig", "./runtimeConfig.browser"));
+            // Add the ReactNative hook.
+            node = node.withMember("react-native", Node.objectNode()
+                    .withMember("./runtimeConfig", "./runtimeConfig.native"));
+        }
 
         // Set the package to private if required.
         if (settings.isPrivate()) {

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -48,6 +48,7 @@ public final class TypeScriptSettings {
     private static final String PROTOCOL = "protocol";
     private static final String PRIVATE = "private";
     private static final String GENERATE_CLIENT = "generateClient";
+    private static final String GENERATE_SERVER_SDK = "generateServerSdk";
 
     private String packageName;
     private String packageDescription = "";
@@ -58,6 +59,7 @@ public final class TypeScriptSettings {
     private ShapeId protocol;
     private boolean isPrivate;
     private boolean generateClient;
+    private boolean generateServerSdk;
 
     /**
      * Create a settings object from a configuration object node.
@@ -85,6 +87,8 @@ public final class TypeScriptSettings {
         config.getStringMember(PROTOCOL).map(StringNode::getValue).map(ShapeId::from).ifPresent(settings::setProtocol);
         settings.setPrivate(config.getBooleanMember(PRIVATE).map(BooleanNode::getValue).orElse(false));
         settings.setGenerateClient(config.getBooleanMember(GENERATE_CLIENT).map(BooleanNode::getValue).orElse(true));
+        settings.setGenerateServerSdk(
+                config.getBooleanMember(GENERATE_SERVER_SDK).map(BooleanNode::getValue).orElse(true));
 
         settings.setPluginSettings(config);
         return settings;
@@ -228,6 +232,19 @@ public final class TypeScriptSettings {
 
     public void setGenerateClient(boolean generateClient) {
         this.generateClient = generateClient;
+    }
+
+    /**
+     * Returns if the generated package will include a server sdk.
+     *
+     * @return If the package will include a server sdk.
+     */
+    public boolean generateServerSdk() {
+        return generateServerSdk;
+    }
+
+    public void setGenerateServerSdk(boolean generateServerSdk) {
+        this.generateServerSdk = generateServerSdk;
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -47,6 +47,7 @@ public final class TypeScriptSettings {
     private static final String SERVICE = "service";
     private static final String PROTOCOL = "protocol";
     private static final String PRIVATE = "private";
+    private static final String GENERATE_CLIENT = "generateClient";
 
     private String packageName;
     private String packageDescription = "";
@@ -56,6 +57,7 @@ public final class TypeScriptSettings {
     private ObjectNode pluginSettings = Node.objectNode();
     private ShapeId protocol;
     private boolean isPrivate;
+    private boolean generateClient;
 
     /**
      * Create a settings object from a configuration object node.
@@ -82,6 +84,7 @@ public final class TypeScriptSettings {
         settings.packageJson = config.getObjectMember(PACKAGE_JSON).orElse(Node.objectNode());
         config.getStringMember(PROTOCOL).map(StringNode::getValue).map(ShapeId::from).ifPresent(settings::setProtocol);
         settings.setPrivate(config.getBooleanMember(PRIVATE).map(BooleanNode::getValue).orElse(false));
+        settings.setGenerateClient(config.getBooleanMember(GENERATE_CLIENT).map(BooleanNode::getValue).orElse(true));
 
         settings.setPluginSettings(config);
         return settings;
@@ -212,6 +215,19 @@ public final class TypeScriptSettings {
 
     public void setPrivate(boolean isPrivate) {
         this.isPrivate = isPrivate;
+    }
+
+    /**
+     * Returns if the generated package will include a client.
+     *
+     * @return If the package will include a client.
+     */
+    public boolean generateClient() {
+        return generateClient;
+    }
+
+    public void setGenerateClient(boolean generateClient) {
+        this.generateClient = generateClient;
     }
 
     /**

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/TypeScriptSettings.java
@@ -88,7 +88,7 @@ public final class TypeScriptSettings {
         settings.setPrivate(config.getBooleanMember(PRIVATE).map(BooleanNode::getValue).orElse(false));
         settings.setGenerateClient(config.getBooleanMember(GENERATE_CLIENT).map(BooleanNode::getValue).orElse(true));
         settings.setGenerateServerSdk(
-                config.getBooleanMember(GENERATE_SERVER_SDK).map(BooleanNode::getValue).orElse(true));
+                config.getBooleanMember(GENERATE_SERVER_SDK).map(BooleanNode::getValue).orElse(false));
 
         settings.setPluginSettings(config);
         return settings;

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1179,8 +1179,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             pathRegexBuilder.append("/");
         }
         writer.write("const pathRegex = new RegExp($S);", pathRegexBuilder.toString());
-        writer.write("const parsedPath: RegExpMatchArray = output.endpoint.path.match(pathRegex);");
-        writer.openBlock("if (parsedPath.groups !== undefined) {", "}", () -> {
+        writer.write("const parsedPath = output.path.match(pathRegex);");
+        writer.openBlock("if (parsedPath?.groups !== undefined) {", "}", () -> {
             for (HttpBinding binding : pathBindings) {
                 Shape target = context.getModel().expectShape(binding.getMember().getTarget());
                 String memberName = context.getSymbolProvider().toMemberName(binding.getMember());
@@ -1211,9 +1211,9 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
             }
         }
         writer.write("const hostRegex = new RegExp($S);", endpointRegexBuilder.toString());
-        writer.write("const parsedHost: RegExpMatchArray = output.endpoint.path.match(pathRegex);");
+        writer.write("const parsedHost = output.path.match(pathRegex);");
         Shape input = context.getModel().expectShape(operation.getInput().get());
-        writer.openBlock("if (parsedHost.groups !== undefined) {", "}", () -> {
+        writer.openBlock("if (parsedHost?.groups !== undefined) {", "}", () -> {
             for (MemberShape member : input.members()) {
                 if (member.hasTrait(HostLabelTrait.class)) {
                     Shape target = context.getModel().expectShape(member.getTarget());

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -159,21 +159,14 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
     @Override
     public void generateRequestSerializers(GenerationContext context) {
-        TopDownIndex topDownIndex = context.getModel().getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(context.getModel());
 
         Set<OperationShape> containedOperations = new TreeSet<>(
                 topDownIndex.getContainedOperations(context.getService()));
         for (OperationShape operation : containedOperations) {
             OptionalUtils.ifPresentOrElse(
                     operation.getTrait(HttpTrait.class),
-                    httpTrait -> {
-                        if (context.getSettings().generateClient()) {
-                            generateOperationRequestSerializer(context, operation, httpTrait);
-                        }
-                        if (context.getSettings().generateServerSdk()) {
-                            generateOperationResponseSerializer(context, operation, httpTrait);
-                        }
-                    },
+                    httpTrait -> generateOperationRequestSerializer(context, operation, httpTrait),
                     () -> LOGGER.warning(String.format(
                             "Unable to generate %s protocol request bindings for %s because it does not have an "
                             + "http binding trait", getName(), operation.getId())));
@@ -181,22 +174,48 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
     @Override
-    public void generateResponseDeserializers(GenerationContext context) {
-        TopDownIndex topDownIndex = context.getModel().getKnowledge(TopDownIndex.class);
+    public void generateRequestDeserializers(GenerationContext context) {
+        TopDownIndex topDownIndex = TopDownIndex.of(context.getModel());
 
         Set<OperationShape> containedOperations = new TreeSet<>(
                 topDownIndex.getContainedOperations(context.getService()));
         for (OperationShape operation : containedOperations) {
             OptionalUtils.ifPresentOrElse(
                     operation.getTrait(HttpTrait.class),
-                    httpTrait -> {
-                        if (context.getSettings().generateClient()) {
-                            generateOperationResponseDeserializer(context, operation, httpTrait);
-                        }
-                        if (context.getSettings().generateServerSdk()) {
-                            generateOperationRequestDeserializer(context, operation, httpTrait);
-                        }
-                    },
+                    httpTrait -> generateOperationRequestDeserializer(context, operation, httpTrait),
+                    () -> LOGGER.warning(String.format(
+                            "Unable to generate %s protocol request bindings for %s because it does not have an "
+                            + "http binding trait", getName(), operation.getId())));
+        }
+
+    }
+
+    @Override
+    public void generateResponseSerializers(GenerationContext context) {
+        TopDownIndex topDownIndex = TopDownIndex.of(context.getModel());
+
+        Set<OperationShape> containedOperations = new TreeSet<>(
+                topDownIndex.getContainedOperations(context.getService()));
+        for (OperationShape operation : containedOperations) {
+            OptionalUtils.ifPresentOrElse(
+                    operation.getTrait(HttpTrait.class),
+                    httpTrait -> generateOperationRequestSerializer(context, operation, httpTrait),
+                    () -> LOGGER.warning(String.format(
+                            "Unable to generate %s protocol response bindings for %s because it does not have an "
+                            + "http binding trait", getName(), operation.getId())));
+        }
+    }
+
+    @Override
+    public void generateResponseDeserializers(GenerationContext context) {
+        TopDownIndex topDownIndex = TopDownIndex.of(context.getModel());
+
+        Set<OperationShape> containedOperations = new TreeSet<>(
+                topDownIndex.getContainedOperations(context.getService()));
+        for (OperationShape operation : containedOperations) {
+            OptionalUtils.ifPresentOrElse(
+                    operation.getTrait(HttpTrait.class),
+                    httpTrait -> generateOperationRequestDeserializer(context, operation, httpTrait),
                     () -> LOGGER.warning(String.format(
                             "Unable to generate %s protocol response bindings for %s because it does not have an "
                             + "http binding trait", getName(), operation.getId())));

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -248,7 +248,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         writer.openBlock("export const $L = async(\n"
                 + "  input: $T,\n"
-                + "  context: $L\n"
+                + "  context: Omit<$L, 'endpoint'>\n"
                 + "): Promise<$T> => {", "}", methodName, outputType, contextType, responseType, () -> {
             writeOperationStatusCode(context, operation, bindingIndex, trait);
             writeResponseHeaders(context, operation, bindingIndex, () -> writeDefaultHeaders(context, operation));
@@ -287,7 +287,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
 
         writer.openBlock("export const $L = async(\n"
                 + "  input: $T,\n"
-                + "  context: __SerdeContext\n"
+                + "  context: Omit<__SerdeContext, 'endpoint'>\n"
                 + "): Promise<$T> => {", "}", methodName, symbol, responseType, () -> {
             writeErrorStatusCode(context, error);
             writeResponseHeaders(context, error, bindingIndex, () -> writeDefaultErrorHeaders(context, error));

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -881,7 +881,8 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
      * @param context The generation context.
      * @param error The error being generated.
      */
-    protected void writeDefaultErrorHeaders(GenerationContext context, StructureShape error) {}
+    protected void writeDefaultErrorHeaders(GenerationContext context, StructureShape error) {
+    }
 
     /**
      * Writes the code needed to serialize the input document of a request.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1281,7 +1281,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
     }
 
     /**
-     * Reads headers that are 1-1 mapped to members via the @httpHeader trait
+     * Reads headers that are 1-1 mapped to members via the @httpHeader trait.
      *
      * @param context the generation context.
      * @param headerBindings a collection of header bindings.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -242,7 +242,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         TypeScriptWriter writer = context.getWriter();
 
         writer.addUseImports(responseType);
-        String methodName = ProtocolGenerator.getSerFunctionName(symbol, getName()) + "Response";
+        String methodName = ProtocolGenerator.getGenericSerFunctionName(symbol) + "Response";
         Symbol outputType = symbol.expectProperty("outputType", Symbol.class);
         String contextType = CodegenUtils.getOperationSerializerContextType(writer, context.getModel(), operation);
 
@@ -283,7 +283,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         TypeScriptWriter writer = context.getWriter();
 
         writer.addUseImports(responseType);
-        String methodName = ProtocolGenerator.getSerFunctionName(symbol, getName()) + "Error";
+        String methodName = ProtocolGenerator.getGenericSerFunctionName(symbol) + "Error";
 
         writer.openBlock("export const $L = async(\n"
                 + "  input: $T,\n"
@@ -1099,7 +1099,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         // Ensure that the request type is imported.
         writer.addUseImports(requestType);
         writer.addImport("Endpoint", "__Endpoint", "@aws-sdk/types");
-        String methodName = ProtocolGenerator.getDeserFunctionName(symbol, getName()) + "Request";
+        String methodName = ProtocolGenerator.getGenericDeserFunctionName(symbol) + "Request";
         // Add the normalized input type.
         Symbol inputType = symbol.expectProperty("inputType", Symbol.class);
         String contextType = CodegenUtils.getOperationSerializerContextType(writer, context.getModel(), operation);

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -199,7 +199,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         for (OperationShape operation : containedOperations) {
             OptionalUtils.ifPresentOrElse(
                     operation.getTrait(HttpTrait.class),
-                    httpTrait -> generateOperationRequestSerializer(context, operation, httpTrait),
+                    httpTrait -> generateOperationResponseSerializer(context, operation, httpTrait),
                     () -> LOGGER.warning(String.format(
                             "Unable to generate %s protocol response bindings for %s because it does not have an "
                             + "http binding trait", getName(), operation.getId())));
@@ -215,7 +215,7 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         for (OperationShape operation : containedOperations) {
             OptionalUtils.ifPresentOrElse(
                     operation.getTrait(HttpTrait.class),
-                    httpTrait -> generateOperationRequestDeserializer(context, operation, httpTrait),
+                    httpTrait -> generateOperationResponseDeserializer(context, operation, httpTrait),
                     () -> LOGGER.warning(String.format(
                             "Unable to generate %s protocol response bindings for %s because it does not have an "
                             + "http binding trait", getName(), operation.getId())));

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpBindingProtocolGenerator.java
@@ -1169,15 +1169,15 @@ public abstract class HttpBindingProtocolGenerator implements ProtocolGenerator 
         if (pathBindings.isEmpty()) {
             return;
         }
-        StringBuilder pathRegexBuilder = new StringBuilder("/");
+        StringBuilder pathRegexBuilder = new StringBuilder();
         for (Segment segment : trait.getUri().getSegments()) {
+            pathRegexBuilder.append("/");
             if (segment.isLabel()) {
                 // Create a named capture group for the segment so we can grab it later without regard to order.
                 pathRegexBuilder.append(String.format("(?<%s>.*)", segment.getContent()));
             } else {
                 pathRegexBuilder.append(segment.getContent());
             }
-            pathRegexBuilder.append("/");
         }
         writer.write("const pathRegex = new RegExp($S);", pathRegexBuilder.toString());
         writer.write("const parsedPath = output.path.match(pathRegex);");

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/HttpRpcProtocolGenerator.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.typescript.codegen.integration;
 
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.logging.Logger;
 import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.codegen.core.SymbolReference;
@@ -34,6 +35,8 @@ import software.amazon.smithy.utils.OptionalUtils;
  * Abstract implementation useful for all HTTP protocols without bindings.
  */
 public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
+
+    public static final Logger LOGGER = Logger.getLogger(HttpRpcProtocolGenerator.class.getName());
 
     private final Set<Shape> serializingDocumentShapes = new TreeSet<>();
     private final Set<Shape> deserializingDocumentShapes = new TreeSet<>();
@@ -138,6 +141,16 @@ public abstract class HttpRpcProtocolGenerator implements ProtocolGenerator {
         for (OperationShape operation : containedOperations) {
             generateOperationSerializer(context, operation);
         }
+    }
+
+    @Override
+    public void generateRequestDeserializers(GenerationContext context) {
+        LOGGER.warning("Request deserialization is not currently supported for RPC protocols.");
+    }
+
+    @Override
+    public void generateResponseSerializers(GenerationContext context) {
+        LOGGER.warning("Response serialization is not currently supported for RPC protocols.");
     }
 
     @Override

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -134,6 +134,22 @@ public interface ProtocolGenerator {
 
     /**
      * Generates the code used to deserialize the shapes of a service
+     * for requests.
+     *
+     * @param context Serialization context.
+     */
+    void generateRequestDeserializers(GenerationContext context);
+
+    /**
+     * Generates the code used to serialize the shapes of a service
+     * for responses.
+     *
+     * @param context Serialization context.
+     */
+    void generateResponseSerializers(GenerationContext context);
+
+    /**
+     * Generates the code used to deserialize the shapes of a service
      * for responses.
      *
      * @param context Deserialization context.

--- a/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
+++ b/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/integration/ProtocolGenerator.java
@@ -174,6 +174,17 @@ public interface ProtocolGenerator {
     }
 
     /**
+     * Generates the name of a serializer function for shapes of a service that is not protocol-specific.
+     *
+     * @param symbol The symbol the serializer function is being generated for.
+     * @return Returns the generated function name.
+     */
+    static String getGenericSerFunctionName(Symbol symbol) {
+        // e.g., serializeExecuteStatement
+        return "serialize" + getSerdeFunctionSymbolComponent(symbol, symbol.expectProperty("shape", Shape.class));
+    }
+
+    /**
      * Generates the name of a deserializer function for shapes of a service.
      *
      * @param symbol The symbol the deserializer function is being generated for.
@@ -188,6 +199,18 @@ public interface ProtocolGenerator {
         functionName += getSerdeFunctionSymbolComponent(symbol, symbol.expectProperty("shape", Shape.class));
 
         return functionName;
+    }
+
+    /**
+     * Generates the name of a deserializer function for shapes of a service that is not protocol-specific.
+     *
+     * @param symbol The symbol the deserializer function is being generated for.
+     * @return Returns the generated function name.
+     */
+    static String getGenericDeserFunctionName(Symbol symbol) {
+        // e.g., deserializeExecuteStatement
+        return "deserialize"
+                + getSerdeFunctionSymbolComponent(symbol, symbol.expectProperty("shape", Shape.class));
     }
 
     static String getSerdeFunctionSymbolComponent(Symbol symbol, Shape shape) {

--- a/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IndexGeneratorTest.java
+++ b/smithy-typescript-codegen/src/test/java/software/amazon/smithy/typescript/codegen/IndexGeneratorTest.java
@@ -22,7 +22,7 @@ public class IndexGeneratorTest {
         SymbolProvider symbolProvider = TypeScriptCodegenPlugin.createSymbolProvider(model);
         MockManifest manifest = new MockManifest();
 
-        IndexGenerator.writeIndex(settings, model, symbolProvider, manifest);
+        IndexGenerator.writeIndex(settings, model, symbolProvider, manifest, null);
 
         String contents = manifest.getFileString("index.ts").get();
         assertThat(contents, containsString("export * from \"./Example\";"));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Two issues cropped up while hacking together the demo:

1. path parsing was appending a trailing `/`, which would never match the swagger def/user input

2. after compilation, the serde functions were not importable (and their names were ugly). This makes the import statement look like this:

`import { Aws_restJson1 } from "@bootleg-service/server-bootleg";`

and the usage look like this:

```
           return Aws_restJson1.serializeGetVenueCommandResponse(
               {...response.output, $metadata: response.metadata },
               serdeContextBase);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
